### PR TITLE
Surround content with span tag

### DIFF
--- a/moment-js.html
+++ b/moment-js.html
@@ -23,7 +23,7 @@ Example:
 <dom-module id="moment-js">
   <template>
     <template is="dom-if" if="[[!hide]]">
-      [[formattedDate]]
+      <span>[[formattedDate]]</span>
     </template>
   </template>
 

--- a/moment-js.html
+++ b/moment-js.html
@@ -22,9 +22,7 @@ Example:
 
 <dom-module id="moment-js">
   <template>
-    <template is="dom-if" if="[[!hide]]">
-      <span>[[formattedDate]]</span>
-    </template>
+    <span hidden$="[[hide]]">[[formattedDate]]</span>
   </template>
 
   <script>


### PR DESCRIPTION
This commit surrounds the element content with a span tags to avoid
useless whitespaces.

fixes #4
