### PR TITLE
Decrease observer calls

### DIFF
--- a/moment-js.html
+++ b/moment-js.html
@@ -58,7 +58,8 @@ Example:
          * Date parameter
          */
         date: {
-          type: String
+          type: String,
+          value: Date
         },
 
         /**
@@ -175,9 +176,7 @@ Example:
 
       observers: [
         '_checkAndSetIfDateIsNumber(date)',
-        '_updateFormattedDateMoment(date)',
-        '_updateFormattedDateMoment(dateFormat)',
-        '_updateFormattedDateMoment(utc)',
+        '_updateFormattedDateMoment(date, dateFormat, utc)',
         '_updateFormattedDate(format)'
       ],
 

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -108,6 +108,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(els.length, 0, 'zero distributed node');
     });
 
+    test('default value is the current date', function() {
+      assert.equal(myEl.date, new Date());
+    });
+
   });
 </script>
 


### PR DESCRIPTION
This commit avoids to use three times of the same observer on three
properties and sets one observer for all of those three properties. This
reduces the number of calls. For example, on the demo page, the observer
was triggered 25 times instead of 9 times with the new version. As you
can see, the default value of the date is the current one.

Closes #15
