### PR TITLE
Fix relative path of momentjs import

### DIFF
--- a/moment-import-behavior.html
+++ b/moment-import-behavior.html
@@ -18,23 +18,16 @@
     },
 
     /**
-     * Load momentjs library from local.
+     * Loads momentjs library from local.
      *
      * @private
-       */
-    _loadMomentJs: function () {
-      var thiz = this;
-
+     */
+    _loadMomentJs: function() {
       var script = document.createElement('script');
-
-      /**
-       * TODO: Fix relative path.
-       * There is an issue for relative paths in JS. Check #1
-       */
-      script.src = '../../moment/min/moment.min.js';
-      script.onload = function () {
-        thiz.fire('moment-is-ready');
-      };
+      script.src = this.resolveUrl('../moment/min/moment.min.js');
+      script.onload = function() {
+        this.fire('moment-is-ready');
+      }.bind(this);
       document.body.appendChild(script);
     },
 


### PR DESCRIPTION
This commit uses the [Polymer.Base#method-resolveUrl](https://www.polymer-project.org/1.0/docs/api/Polymer.Base#method-resolveUrl) method to set the
src attribute of the injected script tag which will load momentjs.
