### PR TITLE
Fix display update of relative time

### DIFF
--- a/moment-js.html
+++ b/moment-js.html
@@ -217,13 +217,28 @@ Example:
           }
 
           this._updateFormattedDate();
+          this._updateRelativeTime();
         }
       },
 
       _updateFormattedDate: function () {
         if (this.formattedDateMoment) {
           this._setFormattedDate(this.formattedDateMoment.format(this.format));
-          this._setOutput(this.formattedDate);
+          if (!this.relativeTime) {
+            this._setOutput(this.formattedDate);
+          }
+        }
+      },
+
+      _updateRelativeTime: function() {
+        if (this.formattedDateMoment) {
+          if (this.fromNow) {
+            this._setRelativeTime(this.formattedDateMoment.fromNow());
+            this._setOutput(this.relativeTime);
+          } else if (this.toNow) {
+            this._setRelativeTime(this.formattedDateMoment.toNow());
+            this._setOutput(this.relativeTime);
+          }
         }
       },
 
@@ -249,20 +264,6 @@ Example:
         this._updateFormattedDate();
       },
 
-      _fromNowChanged: function () {
-        if (this.fromNow) {
-          this._setRelativeTime(this.formattedDateMoment.fromNow());
-          this._setOutput(this.relativeTime);
-        }
-      },
-
-      _toNowChanged: function () {
-        if (this.toNow) {
-          this._setRelativeTime(this.formattedDateMoment.toNow());
-          this._setOutput(this.relativeTime);
-        }
-      },
-
       _momentIsReady: function () {
         this.set('isMomentReady', true);
 
@@ -278,8 +279,8 @@ Example:
           '_updateFormattedDate(format)',
           '_startOfChanged(startOf)',
           '_endOfChanged(endOf)',
-          '_fromNowChanged(fromNow)',
-          '_toNowChanged(toNow)',
+          '_updateRelativeTime(fromNow)',
+          '_updateRelativeTime(toNow)',
           '_updateIsValid(date, dateFormat)'
         ];
 
@@ -288,8 +289,6 @@ Example:
         this._updateFormattedDate(this.format);
         this._startOfChanged(this.startOf);
         this._endOfChanged(this.endOf);
-        this._fromNowChanged(this.fromNow);
-        this._toNowChanged(this.toNow);
         this._updateIsValid(this.date, this.dateFormat);
       }
     });

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -133,6 +133,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('relative time can be updated', function () {
+      myEl.addEventListener('moment-is-ready', function () {
+        myEl.set('date', '08:12');
+        myEl.set('dateFormat', 'HH:mm');
+        myEl.set('toNow', true);
+        myEl.set('date', '10:20');
+        var tempDate = moment('10:20', myEl.dateFormat);
+        assert.equal(myEl.relativeTime, tempDate.toNow());
+        done();
+      });
+    });
+
     test('distributed children', function () {
       myEl.addEventListener('moment-is-ready', function () {
         var els = myEl.getContentChildren();


### PR DESCRIPTION
Before this commit, when the date was updated the display of a relative
time was broken. Instead to display the new relative time the element
was displaying the formatted date. Now, the updated relative time is
properly displayed.

Fixes #22