### PR TITLE
Add calendar-time output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ bower install moment-js
 <moment-js format="YYYY-MM-DD HH:mm:ss"></moment-js>
 <moment-js date="2016-01-10 14:30" date-format="YYYY-MM-DD HH:mm" format="LLLL"></moment-js>
 <moment-js date="2012-09-21" date-format="YYYY-MM-DD" format="LLLL" formatted-date="{{myDate}}" hide></moment-js>
+<moment-js date="2016-01-10 14:30" calendar-time></moment-js>
 ```
 
 ## Docs & Demo

--- a/moment-js.html
+++ b/moment-js.html
@@ -39,6 +39,12 @@ Example:
       date-format="HH:mm"
       from-now></moment-js>
 
+Example:
+
+    <moment-js
+      date="2016-01-10 14:30"
+      calendar-time></moment-js>
+
 
 @demo demo/index.html
 @hero hero.svg
@@ -157,6 +163,13 @@ Example:
         },
 
         /**
+         * Calendar time output. e.g. Last Monday at 2:30 AM, Today at 2:30 AM.
+         */
+        calendarTime: {
+          type: Boolean
+        },
+
+        /**
          * Calculate relativeTime to now.
          * This is similar to fromNow, but gives the opposite interval: fromNow() = - toNow().
          */
@@ -244,6 +257,13 @@ Example:
         this._updateFormattedDate();
       },
 
+      _calendarTimeChanged: function () {
+        if (this.calendarTime) {
+          this._setRelativeTime(this.formattedDateMoment.calendar());
+          this._setOutput(this.relativeTime);
+        }
+      },
+
       _endOfChanged: function () {
         this._setFormattedDateMoment(this.formattedDateMoment.endOf(this.endOf));
         this._updateFormattedDate();
@@ -279,6 +299,7 @@ Example:
           '_startOfChanged(startOf)',
           '_endOfChanged(endOf)',
           '_fromNowChanged(fromNow)',
+          '_calendarTimeChanged(calendarTime)',
           '_toNowChanged(toNow)',
           '_updateIsValid(date, dateFormat)'
         ];
@@ -289,6 +310,7 @@ Example:
         this._startOfChanged(this.startOf);
         this._endOfChanged(this.endOf);
         this._fromNowChanged(this.fromNow);
+        this._calendarTimeChanged(this.calendarTime);
         this._toNowChanged(this.toNow);
         this._updateIsValid(this.date, this.dateFormat);
       }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -133,6 +133,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('calendar time', function () {
+      myEl.addEventListener('moment-is-ready', function () {
+        var date = moment().startOf('month').format();
+        myEl.set('date', date);
+        myEl.set('dateFormat', 'HH:mm');
+        myEl.set('fromNow', true);
+        var tempDate = moment(myEl.date, myEl.dateFormat);
+        assert.equal(myEl.relativeTime, tempDate.calendar());
+        done();
+      });
+    });
+
     test('distributed children', function () {
       myEl.addEventListener('moment-is-ready', function () {
         var els = myEl.getContentChildren();


### PR DESCRIPTION
This commit adds a calendar time output option as described in the moment documentation -https://momentjs.com/docs/#/displaying/calendar-time/

```html
<moment-js date="2016-01-10 14:30" calendar-time></moment-js>
<!-- Last Monday at 2:30 PM -->
```

Fixes #24