### PR TITLE
chore(travis): use polymer cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
     packages:
       - google-chrome-stable
 before_script:
-  - npm install -g bower polylint web-component-tester
-  - bower install
-  - polylint
+  - npm install -g polymer-cli
+  - polymer install
+  - polymer lint --rules polymer-1
 script:
-  - xvfb-run wct --skip-plugin sauce
+  - xvfb-run polymer test --skip-plugin sauce

--- a/bower.json
+++ b/bower.json
@@ -29,5 +29,8 @@
     "github-fork-ribbon": "^0.2.0",
     "demo-snippet": "^1.0.0",
     "paper-input": "PolymerElements/paper-input#^2.0.3"
+  },
+  "resolutions": {
+    "webcomponentsjs": "^0.7.24"
   }
 }


### PR DESCRIPTION
With this commit, Travis CI use the Polymer CLI to install and lint the
project instead of using seperated tools.

closes #32